### PR TITLE
Use error returns in place of a few panics

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import (
 )
 
 func main() {
-	h, _ := sumhash.New512(nil)
+	h := sumhash.New512()
 	input := []byte("sumhash input")
 	_, _ = h.Write(input)
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import (
 )
 
 func main() {
-	h := sumhash.New512(nil)
+	h, _ := sumhash.New512(nil)
 	input := []byte("sumhash input")
 	_, _ = h.Write(input)
 

--- a/compress.go
+++ b/compress.go
@@ -20,7 +20,7 @@ type LookupTable [][][256]uint64
 // m must be a multiple of 8.
 func RandomMatrix(rand io.Reader, n int, m int) (Matrix, error) {
 	if m%8 != 0 {
-		panic(fmt.Errorf("m=%d is not a multiple of 8", m))
+		return Matrix{}, fmt.Errorf("m=%d is not a multiple of 8", m)
 	}
 
 	A := make([][]uint64, n)
@@ -87,7 +87,7 @@ func sumBits(as []uint64, b byte) uint64 {
 
 // Compressor represents the compression function which is performed on a message
 type Compressor interface {
-	Compress(dst []byte, input []byte)
+	Compress(dst []byte, input []byte) error
 	InputLen() int  // len(input)
 	OutputLen() int // len(dst)
 }
@@ -106,12 +106,12 @@ func (A Matrix) InputLen() int {
 func (A Matrix) OutputLen() int { return len(A) * 8 }
 
 // Compress performs the compression algorithm on a message and output into dst
-func (A Matrix) Compress(dst []byte, msg []byte) {
+func (A Matrix) Compress(dst []byte, msg []byte) error {
 	if len(msg) != A.InputLen() {
-		panic(fmt.Errorf("could not compress message. input size is wrong. size is %d, expected %d", len(msg), A.InputLen()))
+		return fmt.Errorf("could not compress message. input size is wrong. size is %d, expected %d", len(msg), A.InputLen())
 	}
 	if len(dst) != A.OutputLen() {
-		panic(fmt.Errorf("could not compress message. output size is wrong size is %d, expected %d", len(dst), A.OutputLen()))
+		return fmt.Errorf("could not compress message. output size is wrong size is %d, expected %d", len(dst), A.OutputLen())
 	}
 
 	// this allows go to eliminate the bound check when accessing the slice
@@ -140,6 +140,7 @@ func (A Matrix) Compress(dst []byte, msg []byte) {
 		}
 		binary.LittleEndian.PutUint64(dst[8*i:8*i+8], x)
 	}
+	return nil
 }
 
 // InputLen returns the valid length of a message in bytes
@@ -153,12 +154,12 @@ func (A LookupTable) OutputLen() int {
 }
 
 // Compress performs the compression algorithm on a message and output into dst
-func (A LookupTable) Compress(dst []byte, msg []byte) {
+func (A LookupTable) Compress(dst []byte, msg []byte) error {
 	if len(msg) != A.InputLen() {
-		panic(fmt.Errorf("could not compress message. input size is wrong. size is %d, expected %d", len(msg), A.InputLen()))
+		return fmt.Errorf("could not compress message. input size is wrong. size is %d, expected %d", len(msg), A.InputLen())
 	}
 	if len(dst) != A.OutputLen() {
-		panic(fmt.Errorf("could not compress message. output size is wrong size is %d, expected %d", len(dst), A.OutputLen()))
+		return fmt.Errorf("could not compress message. output size is wrong size is %d, expected %d", len(dst), A.OutputLen())
 	}
 
 	// this allows go to eliminate the bound check when accessing the slice
@@ -173,4 +174,5 @@ func (A LookupTable) Compress(dst []byte, msg []byte) {
 		}
 		binary.LittleEndian.PutUint64(dst[8*i:8*i+8], x)
 	}
+	return nil
 }

--- a/compress.go
+++ b/compress.go
@@ -87,7 +87,7 @@ func sumBits(as []uint64, b byte) uint64 {
 
 // Compressor represents the compression function which is performed on a message
 type Compressor interface {
-	Compress(dst []byte, input []byte) error
+	Compress(dst []byte, input []byte)
 	InputLen() int  // len(input)
 	OutputLen() int // len(dst)
 }
@@ -106,12 +106,12 @@ func (A Matrix) InputLen() int {
 func (A Matrix) OutputLen() int { return len(A) * 8 }
 
 // Compress performs the compression algorithm on a message and output into dst
-func (A Matrix) Compress(dst []byte, msg []byte) error {
+func (A Matrix) Compress(dst []byte, msg []byte) {
 	if len(msg) != A.InputLen() {
-		return fmt.Errorf("could not compress message. input size is wrong. size is %d, expected %d", len(msg), A.InputLen())
+		panic(fmt.Errorf("could not compress message. input size is wrong. size is %d, expected %d", len(msg), A.InputLen()))
 	}
 	if len(dst) != A.OutputLen() {
-		return fmt.Errorf("could not compress message. output size is wrong size is %d, expected %d", len(dst), A.OutputLen())
+		panic(fmt.Errorf("could not compress message. output size is wrong size is %d, expected %d", len(dst), A.OutputLen()))
 	}
 
 	// this allows go to eliminate the bound check when accessing the slice
@@ -140,7 +140,6 @@ func (A Matrix) Compress(dst []byte, msg []byte) error {
 		}
 		binary.LittleEndian.PutUint64(dst[8*i:8*i+8], x)
 	}
-	return nil
 }
 
 // InputLen returns the valid length of a message in bytes
@@ -154,12 +153,12 @@ func (A LookupTable) OutputLen() int {
 }
 
 // Compress performs the compression algorithm on a message and output into dst
-func (A LookupTable) Compress(dst []byte, msg []byte) error {
+func (A LookupTable) Compress(dst []byte, msg []byte) {
 	if len(msg) != A.InputLen() {
-		return fmt.Errorf("could not compress message. input size is wrong. size is %d, expected %d", len(msg), A.InputLen())
+		panic(fmt.Errorf("could not compress message. input size is wrong. size is %d, expected %d", len(msg), A.InputLen()))
 	}
 	if len(dst) != A.OutputLen() {
-		return fmt.Errorf("could not compress message. output size is wrong size is %d, expected %d", len(dst), A.OutputLen())
+		panic(fmt.Errorf("could not compress message. output size is wrong size is %d, expected %d", len(dst), A.OutputLen()))
 	}
 
 	// this allows go to eliminate the bound check when accessing the slice
@@ -174,5 +173,4 @@ func (A LookupTable) Compress(dst []byte, msg []byte) error {
 		}
 		binary.LittleEndian.PutUint64(dst[8*i:8*i+8], x)
 	}
-	return nil
 }

--- a/sumhash.go
+++ b/sumhash.go
@@ -71,7 +71,7 @@ func (d *digest) Write(p []byte) (nn int, err error) {
 
 	// Check if the new length (in bits) overflows our counter capacity.
 	if uint64(nn) >= (1<<61)-d.len {
-		return 0, fmt.Errorf("length overflow: already wrote %d bytes, trying to write %d bytes", d.len, nn)
+		panic(fmt.Errorf("length overflow: already wrote %d bytes, trying to write %d bytes", d.len, nn))
 	}
 
 	d.len += uint64(nn)

--- a/sumhash512.go
+++ b/sumhash512.go
@@ -26,10 +26,17 @@ func init() {
 
 // New512 creates a new sumhash512 context that computes a sumhash checksum.
 // The output of the hash function is 64 bytes (512 bits).
-// If salt is nil, then hash.Hash computes a hash output in unsalted mode.
-// Otherwise, salt should be 64 bytes, and the hash is computed in salted mode.
-// the context returned by this function reference the salt argument. any changes
-// might affect the hash calculation
-func New512(salt []byte) (hash.Hash, error) {
+// The returned hash.Hash computes a hash output in unsalted mode.
+func New512() hash.Hash {
+	ret, _ := New(SumhashCompressor, nil)
+	return ret
+}
+
+// New512Salted creates a new sumhash512 context that computes a sumhash checksum.
+// The output of the hash function is 64 bytes (512 bits).
+// Salt should be 64 bytes, and the hash is computed in salted mode.
+// The hash.Hash context returned by this function will reference the salt slice:
+// any changes might affect the hash calculation.
+func New512Salted(salt []byte) (hash.Hash, error) {
 	return New(SumhashCompressor, salt)
 }

--- a/sumhash512.go
+++ b/sumhash512.go
@@ -30,6 +30,6 @@ func init() {
 // Otherwise, salt should be 64 bytes, and the hash is computed in salted mode.
 // the context returned by this function reference the salt argument. any changes
 // might affect the hash calculation
-func New512(salt []byte) hash.Hash {
+func New512(salt []byte) (hash.Hash, error) {
 	return New(SumhashCompressor, salt)
 }

--- a/sumhash512_test.go
+++ b/sumhash512_test.go
@@ -48,10 +48,7 @@ var testVector = []testElement{
 
 func TestSumHash512TestVector(t *testing.T) {
 	for i, element := range testVector {
-		h, err := New512(nil)
-		if err != nil {
-			t.Error(err)
-		}
+		h := New512()
 
 		bytesWritten, err := io.WriteString(h, element.input)
 		if err != nil {
@@ -75,10 +72,7 @@ func TestSumHash512(t *testing.T) {
 	v.Write([]byte("sumhash input"))
 	v.Read(input)
 
-	h, err := New512(nil)
-	if err != nil {
-		t.Error(err)
-	}
+	h := New512()
 	bytesWritten, err := h.Write(input)
 	if err != nil {
 		t.Errorf("write returned error : %s", err)
@@ -106,7 +100,7 @@ func TestSumHash512WithSalt(t *testing.T) {
 	v.Write([]byte("sumhash salt"))
 	v.Read(salt)
 
-	h, err := New512(salt)
+	h, err := New512Salted(salt)
 	if err != nil {
 		t.Error(err)
 	}
@@ -131,10 +125,7 @@ func TestSumHash512Reset(t *testing.T) {
 	v.Write([]byte("sumhash"))
 	v.Read(input)
 
-	h, err := New512(nil)
-	if err != nil {
-		t.Error(err)
-	}
+	h := New512()
 	h.Write(input)
 	bytesWritten, err := h.Write(input)
 	if err != nil {
@@ -173,10 +164,7 @@ func TestSumHash512ChecksumWithValue(t *testing.T) {
 	v.Write([]byte("sumhash input"))
 	v.Read(input)
 
-	h, err := New512(nil)
-	if err != nil {
-		t.Error(err)
-	}
+	h := New512()
 	bytesWritten, err := h.Write(input)
 	if err != nil {
 		t.Errorf("write returned error : %s", err)
@@ -197,10 +185,7 @@ func TestSumHash512ChecksumWithValue(t *testing.T) {
 }
 
 func TestSumHash512Sizes(t *testing.T) {
-	h, err := New512(nil)
-	if err != nil {
-		t.Error(err)
-	}
+	h := New512()
 	blockSize := h.BlockSize()
 	expectedBlockSizeInBytes := 512 / 8
 	if blockSize != expectedBlockSizeInBytes {
@@ -218,10 +203,7 @@ func BenchmarkHashInterface(b *testing.B) {
 	msg := make([]byte, 600)
 
 	rand.Read(msg)
-	h, err := New512(nil)
-	if err != nil {
-		b.Error(err)
-	}
+	h := New512()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/sumhash512_test.go
+++ b/sumhash512_test.go
@@ -48,7 +48,10 @@ var testVector = []testElement{
 
 func TestSumHash512TestVector(t *testing.T) {
 	for i, element := range testVector {
-		h := New512(nil)
+		h, err := New512(nil)
+		if err != nil {
+			t.Error(err)
+		}
 
 		bytesWritten, err := io.WriteString(h, element.input)
 		if err != nil {
@@ -72,7 +75,10 @@ func TestSumHash512(t *testing.T) {
 	v.Write([]byte("sumhash input"))
 	v.Read(input)
 
-	h := New512(nil)
+	h, err := New512(nil)
+	if err != nil {
+		t.Error(err)
+	}
 	bytesWritten, err := h.Write(input)
 	if err != nil {
 		t.Errorf("write returned error : %s", err)
@@ -100,7 +106,10 @@ func TestSumHash512WithSalt(t *testing.T) {
 	v.Write([]byte("sumhash salt"))
 	v.Read(salt)
 
-	h := New512(salt)
+	h, err := New512(salt)
+	if err != nil {
+		t.Error(err)
+	}
 	bytesWritten, err := h.Write(input)
 	if err != nil {
 		t.Errorf("write returned error : %s", err)
@@ -122,7 +131,10 @@ func TestSumHash512Reset(t *testing.T) {
 	v.Write([]byte("sumhash"))
 	v.Read(input)
 
-	h := New512(nil)
+	h, err := New512(nil)
+	if err != nil {
+		t.Error(err)
+	}
 	h.Write(input)
 	bytesWritten, err := h.Write(input)
 	if err != nil {
@@ -161,7 +173,10 @@ func TestSumHash512ChecksumWithValue(t *testing.T) {
 	v.Write([]byte("sumhash input"))
 	v.Read(input)
 
-	h := New512(nil)
+	h, err := New512(nil)
+	if err != nil {
+		t.Error(err)
+	}
 	bytesWritten, err := h.Write(input)
 	if err != nil {
 		t.Errorf("write returned error : %s", err)
@@ -182,7 +197,10 @@ func TestSumHash512ChecksumWithValue(t *testing.T) {
 }
 
 func TestSumHash512Sizes(t *testing.T) {
-	h := New512(nil)
+	h, err := New512(nil)
+	if err != nil {
+		t.Error(err)
+	}
 	blockSize := h.BlockSize()
 	expectedBlockSizeInBytes := 512 / 8
 	if blockSize != expectedBlockSizeInBytes {
@@ -200,7 +218,10 @@ func BenchmarkHashInterface(b *testing.B) {
 	msg := make([]byte, 600)
 
 	rand.Read(msg)
-	h := New512(nil)
+	h, err := New512(nil)
+	if err != nil {
+		b.Error(err)
+	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/sumhash_test.go
+++ b/sumhash_test.go
@@ -25,8 +25,14 @@ func TestHashResult(t *testing.T) {
 	}
 	At := A.LookupTable()
 
-	h1 := New(A, nil)
-	h2 := New(At, nil)
+	h1, err := New(A, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	h2, err := New(At, nil)
+	if err != nil {
+		t.Error(err)
+	}
 
 	bytesWritten, err := io.WriteString(h1, testElement[0])
 	if err != nil || bytesWritten != len(testElement[0]) {
@@ -63,8 +69,14 @@ func testHashParams(t *testing.T, n int, m int) {
 	}
 	At := A.LookupTable()
 
-	h1 := New(A, nil)
-	h2 := New(At, nil)
+	h1, err := New(A, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	h2, err := New(At, nil)
+	if err != nil {
+		t.Error(err)
+	}
 
 	if h1.Size() != n*8 || h1.BlockSize() != m/8-n*8 {
 		t.Errorf("h1 has unexpected size/blocksize values")


### PR DESCRIPTION
This switches out a panic in favor of an error return, in keeping with the advice in https://github.com/golang/go/wiki/CodeReviewComments#dont-panic
